### PR TITLE
Cherry-pick 2.3 changes to 3.0

### DIFF
--- a/app/models/spree/subscription.rb
+++ b/app/models/spree/subscription.rb
@@ -183,10 +183,12 @@ module Spree
     end
 
     def last_skip
-      skips.last if skips.any? && skips.last.undo_at.nil? && skips.last.renewed_at.nil?
+      skips.last if active_skips?
     end
 
-    alias_attribute :skipping?, :last_skip
+    def skipping?
+      skips.last if active_skips? && skips.last.skip_at.to_date >= Date.today
+    end
 
     def can_skip
       # only allow skipping after date has pass
@@ -248,5 +250,10 @@ module Spree
       }))
     end
 
+    private
+
+    def active_skips?
+      skips.any? && skips.last.undo_at.nil? && skips.last.renewed_at.nil?
+    end
   end
 end

--- a/app/models/spree/subscription_skip_link.rb
+++ b/app/models/spree/subscription_skip_link.rb
@@ -1,0 +1,15 @@
+module Spree
+  class SubscriptionSkipLink < ActiveRecord::Base
+    belongs_to :user, class_name: 'Spree::User'
+    belongs_to :subscription, class_name: 'Spree::Subscription'
+
+    validates_presence_of   :user, :subscription
+    validates_uniqueness_of :token
+
+    private
+
+    def generate_token(prefix = 0)
+      "#{prefix}"-"#{SecureRandom.uuid}".freeze
+    end
+  end
+end

--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -3,6 +3,7 @@ module Spree
 
     def self.prepended(base)
       base.has_many :subscriptions
+      base.has_many :subscription_skip_links, class_name: 'Spree::SubscriptionSkipLink'
     end
 
     def subscription_orders

--- a/app/serializers/subscription_item_serializer.rb
+++ b/app/serializers/subscription_item_serializer.rb
@@ -1,6 +1,5 @@
 class SubscriptionItemSerializer < ActiveModel::Serializer
   extend Spree::Api::ApiHelpers
-  cached
   delegate :cache_key, to: :object
 
   attributes :id, :quantity, :price

--- a/app/serializers/subscription_serializer.rb
+++ b/app/serializers/subscription_serializer.rb
@@ -1,6 +1,5 @@
 class SubscriptionSerializer < ActiveModel::Serializer
   extend Spree::Api::ApiHelpers
-  cached
   delegate :cache_key, to: :object
 
   attributes :id, :interval, :state, :next_shipment_date, :skip_order_at, :email, :can_skip

--- a/app/serializers/subscription_skip_serializer.rb
+++ b/app/serializers/subscription_skip_serializer.rb
@@ -1,6 +1,5 @@
 class SubscriptionSkipSerializer < ActiveModel::Serializer
   extend Spree::Api::ApiHelpers
-  cached
   delegate :cache_key, to: :object
 
   attributes :id, :skip_at, :undo_at

--- a/app/views/spree/admin/subscriptions/_sidebar.html.erb
+++ b/app/views/spree/admin/subscriptions/_sidebar.html.erb
@@ -20,18 +20,24 @@
         (<%= link_to 'Renew Now', renew_admin_subscription_path(@subscription), method: :put, data: { confirm: 'Are you sure you want to renew the subscription?' } %>)
       </dd>
       <dt>Skip order</dt>
-      <dd><%= @subscription.skip_order_at ? 'Yes' : 'No' %></dd>      
-      <dt>Skip order at</dt>
-      <dd>
-        <%= l(@subscription.skip_order_at, format: :subscription_date_format) if @subscription.skip_order_at %>
-        <% if @subscription.skip_order_at.nil? %>
-        <%= link_to 'Skip Now', skip_admin_subscription_path(@subscription), method: :put %>
-        <% else %>
-        (<%= link_to 'Undo', undo_skip_admin_subscription_path(@subscription), method: :put %>)          
-        <% end %>
-      </dd>      
+      <dd><%= @subscription.skip_order_at ? 'Yes' : 'No' %></dd>
+
+      <% if @subscription.skip_order_until %>
+        <dt>Summer skips:</dt>
+        <dd>
+          Yes
+          <%= link_to 'Undo', undo_skip_admin_subscription_path(@subscription), method: :put if @subscription.skipping? %>
+        </dd>
+      <% else %>
+        <dt>Skip order at</dt>
+        <dd>
+          <%= l(@subscription.skip_order_at, format: :subscription_date_format) if @subscription.skipping? %>
+          <%= link_to 'Skip', skip_admin_subscription_path(@subscription), method: :put if @subscription.can_skip? %>
+          <%= link_to 'Undo', undo_skip_admin_subscription_path(@subscription), method: :put if @subscription.skipping? %>
+        </dd>
+      <% end %>
       <dt>Failed renewals</dt>
-      <dd><%= @subscription.failure_count %></dd>      
+      <dd><%= @subscription.failure_count %></dd>
     <% end %>
     <% if @subscription.paused? %>
       <dt>Paused at</dt>
@@ -48,13 +54,13 @@
     <dt>Shipping Method</dt>
     <dd><%= @subscription.shipping_method.name if @subscription.shipment && @subscription.shipping_method %></dd>
     <dt>Credit card </dt>
-    <% if @subscription.credit_card %> 
+    <% if @subscription.credit_card %>
       <dd><%= link_to @subscription.credit_card.display_number, credit_card_admin_subscription_path(@subscription) %></dd>
-    <% else %>    
+    <% else %>
       <dd><%= link_to Spree.t(:create), credit_card_admin_subscription_path(@subscription) %></dd>
     <% end %>
     <dt>Last updated</dt>
-    <dd><%= l(@subscription.updated_at, format: :long) %></dd>    
+    <dd><%= l(@subscription.updated_at, format: :long) %></dd>
   </dt>
   </header>
 <% end %>

--- a/db/migrate/20170522104058_add_skip_until_to_subscription_skip.rb
+++ b/db/migrate/20170522104058_add_skip_until_to_subscription_skip.rb
@@ -1,5 +1,5 @@
 class AddSkipUntilToSubscriptionSkip < ActiveRecord::Migration
   def change
-    add_column :spree_subscription_skips, :skip_until, :date_time, default: nil
+    add_column :spree_subscription_skips, :skip_until, :datetime, default: nil
   end
 end

--- a/db/migrate/20170522104058_add_skip_until_to_subscription_skip.rb
+++ b/db/migrate/20170522104058_add_skip_until_to_subscription_skip.rb
@@ -1,0 +1,5 @@
+class AddSkipUntilToSubscriptionSkip < ActiveRecord::Migration
+  def change
+    add_column :spree_subscription_skips, :skip_until, :date_time, default: nil
+  end
+end

--- a/db/migrate/20170522140029_create_subscription_skip_links.rb
+++ b/db/migrate/20170522140029_create_subscription_skip_links.rb
@@ -1,0 +1,15 @@
+class CreateSubscriptionSkipLinks < ActiveRecord::Migration
+  def change
+    create_table :spree_subscription_skip_links do |t|
+      t.references :user
+      t.references :subscription
+
+      t.string :token, default: nil
+      t.boolean :used, default: false
+      t.datetime :expires_at
+      t.timestamp
+    end
+
+    add_index :spree_subscription_skip_links, [:user_id, :subscription_id], name: 'subscription_skip_user_idx'
+  end
+end

--- a/db/migrate/20170524113137_add_interval_limit_to_subscription_skip_links.rb
+++ b/db/migrate/20170524113137_add_interval_limit_to_subscription_skip_links.rb
@@ -1,0 +1,5 @@
+class AddIntervalLimitToSubscriptionSkipLinks < ActiveRecord::Migration
+  def change
+    add_column :spree_subscription_skip_links, :interval_limit_at, :datetime
+  end
+end

--- a/db/migrate/20170530171626_add_source_to_skips.rb
+++ b/db/migrate/20170530171626_add_source_to_skips.rb
@@ -1,0 +1,5 @@
+class AddSourceToSkips < ActiveRecord::Migration
+  def change
+    add_column :spree_subscription_skips, :source, :string, default: nil
+  end
+end


### PR DESCRIPTION
In an effort to upgrade to Rails 4.2 and Spree 3.0, this pulls the changes from the 2.3 branch into the 3.0 branch.