### PR TITLE
empty-subscription-bug: added check to avoid crashing the subscription index action

### DIFF
--- a/app/views/spree/admin/subscriptions/index.html.erb
+++ b/app/views/spree/admin/subscriptions/index.html.erb
@@ -100,13 +100,17 @@
           <% end %>
         </td>
         <td>
-          <span class="state <%= subscription.orders.first.state.downcase %>">
-            <%= link_to subscription.orders.first.number, edit_admin_order_path(subscription.last_order), target: '_blank' %>
-          </span>
-          <br />
-          <%= l(subscription.last_order_date, format: :long)  %>
-          <br />
-          <%= subscription.shipping_method.name if subscription.shipment && subscription.shipment.shipping_method %>
+          <% if subscription.orders.any? %>
+            <span class="state <%= subscription.orders.first.state.downcase %>">
+              <%= link_to subscription.orders.first.number, edit_admin_order_path(subscription.last_order), target: '_blank' %>
+            </span>
+            <br />
+            <%= l(subscription.last_order_date, format: :long)  %>
+            <br />
+            <%= subscription.shipping_method.name if subscription.shipment && subscription.shipment.shipping_method %>
+          <% else %>
+            Subscription with empty orders.
+          <% end %>
         </td>
         <td class="align-center">
           <%= link_to(subscription.user.email, edit_admin_user_path(subscription.user), target: '_blank') if subscription.user %>


### PR DESCRIPTION
Some of the subscriptions are being generated without being associated with any order.

This branch intends to mitigate the first symptom, which is, the index action is rendering a partial that is crashing as it tries to access the state of an order, not checking if it exists.